### PR TITLE
Modifications to consider item ledger entries only with entry "Sale" …

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "id": "a7deb28b-d7b1-4543-a5bf-0dfcd66cc093",
   "name": "Keson Customizations",
   "publisher": "Adcirrus ERP",
-  "version": "1.0.0.1",
+  "version": "1.0.0.2",
   "brief": "",
   "description": "",
   "privacyStatement": "",

--- a/src/page/Pag52100.PlanningLines.al
+++ b/src/page/Pag52100.PlanningLines.al
@@ -48,14 +48,17 @@ page 52100 "KES Planning Lines"
                 field("Last 12 Months"; Rec."Last 12 Months")
                 {
                     ToolTip = 'Specifies the value of the Last 12 Month field.', Comment = '%';
+                    Editable = false;
                 }
                 field("Previous 12 Months"; Rec."Previous 12 Months")
                 {
                     ToolTip = 'Specifies the value of the Previous 12 Month field.', Comment = '%';
+                    Editable = false;
                 }
                 field("Per Month Avg."; Rec."Per Month Avg.")
                 {
                     ToolTip = 'Specifies the value of the Per Month Avg. field.';
+                    Editable = false;
                 }
                 field("Purch. Unit of Measure"; Rec."Purch. Unit of Measure")
                 {
@@ -64,6 +67,7 @@ page 52100 "KES Planning Lines"
                 field("Auto Create"; Rec."Auto Create")
                 {
                     ToolTip = 'Specifies the value of the Auto Create field.', Comment = '%';
+                    Visible = false;
                 }
                 field("Ord. Coverage Date"; Rec."Ord. Coverage Date")
                 {

--- a/src/report/Rep52100.CalPlanningLines.al
+++ b/src/report/Rep52100.CalPlanningLines.al
@@ -94,6 +94,8 @@ report 52100 "KES Cal. Planning Lines"
     begin
         StartDate := CalcDate('-1Y', Today);
         EndDate := Today;
+        ItemLedgerEntry.SetCurrentKey("Entry Type", "Item No.", "Variant Code", "Source Type", "Source No.", "Posting Date");
+        ItemLedgerEntry.SetFilter("Entry Type", '%1|%2', ItemLedgerEntry."Entry Type"::Sale, ItemLedgerEntry."Entry Type"::Consumption);
         ItemLedgerEntry.SetRange("Item No.", ItemNo);
         ItemLedgerEntry.SetRange("Posting Date", StartDate, EndDate);
         ItemLedgerEntry.CalcSums(ItemLedgerEntry.Quantity);
@@ -108,7 +110,8 @@ report 52100 "KES Cal. Planning Lines"
     begin
         EndDate := CalcDate('-1Y', Today);
         StartDate := CalcDate('-1Y', EndDate);  //StartDate := CalcDate('-2Y', EndDate);
-
+        ItemLedgerEntry.SetCurrentKey("Entry Type", "Item No.", "Variant Code", "Source Type", "Source No.", "Posting Date");
+        ItemLedgerEntry.SetFilter("Entry Type", '%1|%2', ItemLedgerEntry."Entry Type"::Sale, ItemLedgerEntry."Entry Type"::Consumption);
         ItemLedgerEntry.SetRange("Item No.", ItemNo);
         ItemLedgerEntry.SetRange("Posting Date", StartDate, EndDate);
         ItemLedgerEntry.CalcSums(ItemLedgerEntry.Quantity);


### PR DESCRIPTION
…and "consumption." Made calculated fields non editable.

(cherry picked from commit 35fdaa96e8bac3b1a0fd5e1627e18eeca9e2fd53)